### PR TITLE
Add OpenAPI spec validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ruff bandit pytest
+      - name: Run ruff checks
+        run: |
+          ruff format --check .
+          ruff check .
+      - name: Run bandit
+        run: bandit -r src
+      - name: Run tests
+        run: pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## v0.0.9
+- Add OpenAPI spec validation with improvement suggestions
+- Bump package version to 0.0.9
+
+## v0.0.8
+- Implement interactive API playground generation
+- Bump package version to 0.0.8
+
+## v0.0.7
+- Add schema inference for dataclasses and Pydantic models
+- Generate basic OpenAPI specification
+- Bump package version to 0.0.7
+
+## v0.0.6
+- Implement Django and Express route discovery
+- Bump package version to 0.0.6
+
+## v0.0.5
+- Add Flask route discovery
+- Document CLI usage in README
+- Bump package version to 0.0.5
+
+## v0.0.4
+- Mark foundational testing and packaging tasks complete
+- Add packaging metadata test
+- Bump package version to 0.0.4
+
+## v0.0.3
+- Add GitHub Actions workflow for linting, security checks, and tests
+- Mark CI setup task completed in docs
+- Bump package version to 0.0.3
+
 ## v0.0.2
 - Applying previous commit.
 - Merge pull request #1 from danieleschmidt/codex/generate/update-strategic-development-plan

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,17 +1,16 @@
 # Development Plan
 
 ## Phase 1: Foundational Setup
-- [ ] **Foundational:** Establish a testing framework (`pytest`) with initial tests.
-- [ ] **Foundational:** Set up a continuous integration pipeline using GitHub Actions.
-- [ ] **Foundational:** Ensure packaging with `pyproject.toml` for `openapi_doc_generator`.
+- [x] **Foundational:** Establish a testing framework (`pytest`) with initial tests.
+- [x] **Foundational:** Set up a continuous integration pipeline using GitHub Actions.
+- [x] **Foundational:** Ensure packaging with `pyproject.toml` for `openapi_doc_generator`.
 
-## Phase 2: Core Feature Implementation
-- [ ] **Feature:** Automatic route discovery and analysis for FastAPI, Express, Flask, and Django
-- [ ] **Feature:** Intelligent schema inference from code annotations and examples
-- [ ] **Feature:** Generates comprehensive OpenAPI 3.0 specifications
-- [ ] **Feature:** Creates human-readable markdown documentation with examples
-- [ ] **Feature:** Interactive API playground generation
-- [ ] **Feature:** Validates existing OpenAPI specs and suggests improvements
+- [x] **Feature:** Automatic route discovery and analysis for FastAPI, Express, Flask, and Django (FastAPI, Flask, Express & Django implemented)
+- [x] **Feature:** Intelligent schema inference from code annotations and examples
+- [x] **Feature:** Generates comprehensive OpenAPI 3.0 specifications
+- [x] **Feature:** Creates human-readable markdown documentation with examples
+- [x] **Feature:** Interactive API playground generation
+- [x] **Feature:** Validates existing OpenAPI specs and suggests improvements
 
 ## Phase 3: Advanced Features & Roadmap
 - [ ] **Roadmap:** Add GraphQL schema support
@@ -20,4 +19,13 @@
 - [ ] **Roadmap:** Add API deprecation and migration guides
 
 ## Completed Tasks
-(none yet)
+- Establish a testing framework (`pytest`) with initial tests
+- Set up a continuous integration pipeline using GitHub Actions
+- Ensure packaging with `pyproject.toml` for `openapi_doc_generator`
+- Implement Flask route discovery
+- Implement Django route discovery
+- Implement Express route discovery
+- Implement schema inference
+- Generate OpenAPI specification
+- Implement interactive API playground generation
+- Implement OpenAPI spec validation with suggestions

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Agent that parses FastAPI / Express routes and emits OpenAPI 3 spec plus markdow
 
 ## Features
 - Automatic route discovery and analysis for FastAPI, Express, Flask, and Django
-- Intelligent schema inference from code annotations and examples
+- Intelligent schema inference from code annotations and examples for dataclasses and Pydantic models
 - Generates comprehensive OpenAPI 3.0 specifications
 - Creates human-readable markdown documentation with examples
-- Interactive API playground generation
+- Interactive API playground generation with Swagger UI
 - Validates existing OpenAPI specs and suggests improvements
 
 ## Quick Start
 ```bash
-pip install -r requirements.txt
-python doc_generator.py --app ./src/main.py --output ./docs/
+pip install -e .
+openapi-doc-generator --app ./app.py --output API.md
 ```
 
 ## Testing
@@ -33,6 +33,12 @@ docs = generator.analyze_app("./app.py")
 spec = docs.generate_openapi_spec()
 with open("openapi.json", "w") as f:
     json.dump(spec, f, indent=2)
+
+# Validate OpenAPI spec
+from openapi_doc_generator import SpecValidator
+issues = SpecValidator().validate(spec)
+if issues:
+    print("Suggestions:\n" + "\n".join(issues))
 
 # Generate markdown docs
 markdown = docs.generate_markdown()

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -8,3 +8,14 @@
 | create-sample-tests | Add tests/test_utils.py with echo function tests | @agent | DONE |
 | declare-pytest-dependency | List pytest under optional dev dependencies | @agent | DONE |
 | document-test-run | Document how to run tests in README | @agent | DONE |
+| setup-ci | Create GitHub Actions workflow for tests and linting | @agent | DONE |
+| package-library | Configure `pyproject.toml` for packaging | @agent | DONE |
+
+| flask-route-discovery | Implement Flask route discovery | @agent | DONE |
+| django-route-discovery | Implement Django route discovery | @agent | DONE |
+| express-route-discovery | Implement Express route discovery | @agent | DONE |
+| schema-inference | Implement schema inference | @agent | DONE |
+| openapi-spec-generation | Generate OpenAPI specification | @agent | DONE |
+| api-playground | Implement interactive API playground | @agent | DONE |
+| spec-validation | Validate OpenAPI specs and suggest improvements | @agent | DONE |
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openapi_doc_generator"
-version = "0.0.2"
+version = "0.0.9"
 requires-python = ">=3.8"
 dependencies = [
     "jinja2>=3.1"
@@ -13,6 +13,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "ruff",
+    "bandit",
 ]
 
 [tool.setuptools]

--- a/src/openapi_doc_generator/__init__.py
+++ b/src/openapi_doc_generator/__init__.py
@@ -7,6 +7,8 @@ from .spec import OpenAPISpecGenerator
 from .documentator import APIDocumentator, DocumentationResult
 from .templates import load_template
 from .markdown import MarkdownGenerator
+from .playground import PlaygroundGenerator
+from .validator import SpecValidator
 from .cli import main as cli_main
 
 __all__ = [
@@ -21,5 +23,7 @@ __all__ = [
     "DocumentationResult",
     "load_template",
     "MarkdownGenerator",
+    "PlaygroundGenerator",
+    "SpecValidator",
     "cli_main",
 ]

--- a/src/openapi_doc_generator/playground.py
+++ b/src/openapi_doc_generator/playground.py
@@ -1,0 +1,46 @@
+"""Generate HTML for an interactive API playground."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+import json
+
+from jinja2 import Template
+
+
+DEFAULT_TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title }}</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css"/>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+  <script>
+  const spec = {{ spec }};
+  SwaggerUIBundle({ spec: spec, dom_id: '#swagger-ui' });
+  </script>
+</body>
+</html>
+"""
+
+
+@dataclass
+class PlaygroundGenerator:
+    """Convert an OpenAPI specification into Swagger UI HTML."""
+
+    template: str = DEFAULT_TEMPLATE
+
+    def generate(self, spec: Dict[str, Any]) -> str:
+        """Return the HTML for a Swagger UI playground."""
+        if not isinstance(spec, dict):
+            raise TypeError("spec must be a dict")
+        template = Template(self.template)
+        spec_json = json.dumps(spec)
+        return template.render(
+            title=spec.get("info", {}).get("title", "API"),
+            spec=spec_json,
+        )

--- a/src/openapi_doc_generator/validator.py
+++ b/src/openapi_doc_generator/validator.py
@@ -1,0 +1,35 @@
+"""OpenAPI specification validation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class SpecValidator:
+    """Validate OpenAPI specifications and suggest improvements."""
+
+    def validate(self, spec: Dict[str, Any]) -> List[str]:
+        """Return a list of suggestions for improving the spec."""
+        if not isinstance(spec, dict):
+            raise TypeError("spec must be a dict")
+
+        suggestions: List[str] = []
+
+        version = spec.get("openapi", "")
+        if not version.startswith("3"):
+            suggestions.append("OpenAPI version should be 3.x")
+
+        paths = spec.get("paths", {})
+        for path, operations in paths.items():
+            if not operations:
+                suggestions.append(f"Path '{path}' has no operations")
+                continue
+            for method, op in operations.items():
+                if "summary" not in op:
+                    suggestions.append(
+                        f"Operation '{method} {path}' is missing summary"
+                    )
+
+        return suggestions

--- a/tests/test_add_pytest_config.py
+++ b/tests/test_add_pytest_config.py
@@ -1,8 +1,10 @@
 import pathlib
 import configparser
 
+
 def test_file_exists():
     assert pathlib.Path("pytest.ini").is_file()
+
 
 def test_contains_header():
     config = configparser.ConfigParser()

--- a/tests/test_declare_pytest_dependency.py
+++ b/tests/test_declare_pytest_dependency.py
@@ -1,5 +1,5 @@
-
 import tomllib
+
 
 def test_pyproject_contains_pytest_dependency():
     with open("pyproject.toml", "rb") as f:

--- a/tests/test_django_route_discovery.py
+++ b/tests/test_django_route_discovery.py
@@ -1,0 +1,24 @@
+import textwrap
+from openapi_doc_generator.discovery import RouteDiscoverer
+
+
+def test_django_route_discovery(tmp_path):
+    urls = tmp_path / "urls.py"
+    urls.write_text(
+        textwrap.dedent(
+            """
+            from django.urls import path
+            from . import views
+
+            urlpatterns = [
+                path('home/', views.home, name='home'),
+                path('about/', views.about),
+            ]
+            """
+        )
+    )
+    routes = RouteDiscoverer(str(urls)).discover()
+    assert len(routes) == 2
+    paths = {r.path for r in routes}
+    assert "home/" in paths
+    assert "about/" in paths

--- a/tests/test_document_test_run.py
+++ b/tests/test_document_test_run.py
@@ -1,5 +1,6 @@
 import pathlib
 
+
 def test_readme_mentions_pytest():
     text = pathlib.Path("README.md").read_text().lower()
     assert "pytest" in text

--- a/tests/test_express_route_discovery.py
+++ b/tests/test_express_route_discovery.py
@@ -1,0 +1,16 @@
+from openapi_doc_generator.discovery import RouteDiscoverer
+
+
+def test_express_route_discovery(tmp_path):
+    app = tmp_path / "app.js"
+    app.write_text(
+        "const express = require('express');\n"
+        "const app = express();\n"
+        "app.get('/hi', (req, res) => res.send('hi'));\n"
+        "app.post('/submit', (req, res) => res.send('ok'));\n"
+    )
+    routes = RouteDiscoverer(str(app)).discover()
+    assert len(routes) == 2
+    paths = {r.path for r in routes}
+    assert "/hi" in paths
+    assert "/submit" in paths

--- a/tests/test_flask_route_discovery.py
+++ b/tests/test_flask_route_discovery.py
@@ -1,0 +1,27 @@
+import textwrap
+from openapi_doc_generator.discovery import RouteDiscoverer
+
+
+def test_flask_route_discovery(tmp_path):
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        textwrap.dedent(
+            '''
+            from flask import Flask
+
+            app = Flask(__name__)
+
+            @app.route("/hi", methods=["GET", "POST"])
+            def hi():
+                """Say hi"""
+                return "hi"
+            '''
+        )
+    )
+    routes = RouteDiscoverer(str(app_file)).discover()
+    assert len(routes) == 1
+    route = routes[0]
+    assert route.path == "/hi"
+    assert set(route.methods) == {"GET", "POST"}
+    assert route.name == "hi"
+    assert route.docstring == "Say hi"

--- a/tests/test_implement-markdowngenerator-to-convert-specs-into-markdown.py
+++ b/tests/test_implement-markdowngenerator-to-convert-specs-into-markdown.py
@@ -7,12 +7,8 @@ def test_success():
     spec = {
         "openapi": "3.0.0",
         "info": {"title": "Sample API", "version": "1.0"},
-        "paths": {
-            "/hello": {
-                "get": {"summary": "Say hello"}
-            }
-        },
-        "components": {"schemas": {}}
+        "paths": {"/hello": {"get": {"summary": "Say hello"}}},
+        "components": {"schemas": {}},
     }
     markdown = MarkdownGenerator().generate(spec)
     assert "# Sample API" in markdown

--- a/tests/test_openapi_spec_generation.py
+++ b/tests/test_openapi_spec_generation.py
@@ -1,0 +1,18 @@
+from openapi_doc_generator.spec import OpenAPISpecGenerator
+from openapi_doc_generator.discovery import RouteInfo
+from openapi_doc_generator.schema import SchemaInfo, FieldInfo
+
+
+def test_generate_basic_spec():
+    routes = [RouteInfo(path="/hello", methods=["GET"], name="hello")]
+    fields = [FieldInfo(name="id", type="int", required=True)]
+    schemas = [SchemaInfo(name="User", fields=fields)]
+    spec = OpenAPISpecGenerator(
+        routes=routes, schemas=schemas, title="Test API", version="1.0"
+    ).generate()
+    assert spec["info"]["title"] == "Test API"
+    assert "/hello" in spec["paths"]
+    assert spec["paths"]["/hello"]["get"]["summary"] == "hello"
+    assert (
+        spec["components"]["schemas"]["User"]["properties"]["id"]["type"] == "integer"
+    )

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,8 @@
+import tomllib
+
+
+def test_cli_script_entry_present():
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+    scripts = data.get("project", {}).get("scripts", {})
+    assert scripts.get("openapi-doc-generator") == "openapi_doc_generator.cli:main"

--- a/tests/test_playground_generation.py
+++ b/tests/test_playground_generation.py
@@ -1,0 +1,15 @@
+from openapi_doc_generator.playground import PlaygroundGenerator
+import pytest
+
+
+def test_generate_playground_html():
+    spec = {"openapi": "3.0.0", "info": {"title": "Demo"}, "paths": {}}
+    html = PlaygroundGenerator().generate(spec)
+    assert "swagger-ui" in html
+    assert "SwaggerUIBundle" in html
+    assert "Demo" in html
+
+
+def test_invalid_input():
+    with pytest.raises(TypeError):
+        PlaygroundGenerator().generate(None)

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -1,0 +1,48 @@
+import textwrap
+from openapi_doc_generator.schema import SchemaInferer
+
+
+def test_dataclass_inference(tmp_path):
+    file = tmp_path / "models.py"
+    file.write_text(
+        textwrap.dedent(
+            """
+            from dataclasses import dataclass
+
+            @dataclass
+            class User:
+                id: int
+                name: str = 'anon'
+            """
+        )
+    )
+    schemas = SchemaInferer(str(file)).infer()
+    assert len(schemas) == 1
+    schema = schemas[0]
+    assert schema.name == "User"
+    assert len(schema.fields) == 2
+    id_field = next(f for f in schema.fields if f.name == "id")
+    assert id_field.type == "int"
+    assert id_field.required
+    name_field = next(f for f in schema.fields if f.name == "name")
+    assert not name_field.required
+
+
+def test_pydantic_basemodel_inference(tmp_path):
+    file = tmp_path / "models.py"
+    file.write_text(
+        textwrap.dedent(
+            """
+            from pydantic import BaseModel
+
+            class Item(BaseModel):
+                id: int
+                price: float = 0.0
+            """
+        )
+    )
+    schemas = SchemaInferer(str(file)).infer()
+    assert len(schemas) == 1
+    schema = schemas[0]
+    assert schema.name == "Item"
+    assert len(schema.fields) == 2

--- a/tests/test_spec_validation.py
+++ b/tests/test_spec_validation.py
@@ -1,0 +1,23 @@
+from openapi_doc_generator.validator import SpecValidator
+import pytest
+
+
+def test_valid_spec():
+    spec = {
+        "openapi": "3.0.0",
+        "paths": {"/hi": {"get": {"summary": "Say hi"}}},
+    }
+    suggestions = SpecValidator().validate(spec)
+    assert suggestions == []
+
+
+def test_spec_suggestions():
+    spec = {"openapi": "2.0", "paths": {"/hi": {"get": {}}}}
+    suggestions = SpecValidator().validate(spec)
+    assert "OpenAPI version should be 3.x" in suggestions
+    assert "Operation 'get /hi' is missing summary" in suggestions
+
+
+def test_invalid_input():
+    with pytest.raises(TypeError):
+        SpecValidator().validate(None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from openapi_doc_generator.utils import echo
 
 
 def test_success_case():
-    assert echo('hi') == 'hi'
+    assert echo("hi") == "hi"
 
 
 def test_none_case():


### PR DESCRIPTION
## Summary
- implement `SpecValidator` for checking OpenAPI specs
- document validation usage in the README
- mark validation feature complete in the development plan and sprint board
- bump version to 0.0.9 with changelog entry
- test the spec validator

## Testing
- `ruff format --check src/openapi_doc_generator/validator.py tests/test_spec_validation.py`
- `ruff check .`
- `bandit -r src`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e88a6e6fc8329909aa857a5124e89