### PR TITLE
Increment I3: Community Adoption – implementation tweaks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openapi-docs/core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install ruff bandit pytest
+          pip install ruff bandit pytest coverage radon
       - name: Run ruff checks
         run: |
           ruff format --check .
           ruff check .
       - name: Run bandit
         run: bandit -r src
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: |
+          coverage run -m pytest -q
+          coverage xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml
+      - name: Check complexity
+        run: |
+          radon cc src -n C -s > radon.txt
+          if [ -s radon.txt ]; then
+            cat radon.txt
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
+## v0.1.0
+ - Introduce plugin interface for custom route discovery
+ - Provide built-in aiohttp plugin
+ - Document extension guide and update README
+ - Bump package version to 0.1.0
+
+## v0.0.18
+ - Add CONTRIBUTING guide and CODEOWNERS
+ - Validate CLI `--old-spec` input and log errors
+ - Introduce basic logging across modules
+ - Bump package version to 0.0.18
+
 ## v0.0.17
-- Document completed roadmap and sort changelog entries
-- Bump package version to 0.0.17
+ - Document completed roadmap and sort changelog entries
+ - Bump package version to 0.0.17
 
 ## v0.0.16
 - Allow customizing API title and version via CLI options

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Thank you for helping improve **OpenAPI-Doc-Generator**!
+
+## Setup
+1. Install the project in editable mode:
+   ```bash
+   pip install -e .
+   pip install ruff bandit pytest coverage radon
+   ```
+
+## Running Tests
+Execute the full test suite with:
+```bash
+coverage run -m pytest -q
+coverage html
+```
+
+## Linting
+Format and lint the code before submitting a pull request:
+```bash
+ruff format --check .
+ruff check .
+bandit -r src
+radon cc src -n B
+```

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -1,0 +1,28 @@
+# Extending OpenAPI-Doc-Generator
+
+Plugins can add support for additional web frameworks. Each plugin implements
+the `RoutePlugin` interface and registers itself via `register_plugin`.
+
+```python
+# my_plugin.py
+from openapi_doc_generator import RoutePlugin, register_plugin, RouteInfo
+
+class CustomPlugin(RoutePlugin):
+    def detect(self, source: str) -> bool:
+        return "myframework" in source.lower()
+
+    def discover(self, app_path: str) -> list[RouteInfo]:
+        # inspect app_path and return routes
+        return []
+
+register_plugin(CustomPlugin())
+```
+
+Import your plugin before calling the CLI or API:
+
+```python
+import my_plugin  # registers plugin
+from openapi_doc_generator import RouteDiscoverer
+
+routes = RouteDiscoverer("app.py").discover()
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenAPI-Doc-Generator
 
+![CI](https://github.com/danieleschmidt/openapi-doc-generator/actions/workflows/ci.yml/badge.svg)
+
 Agent that parses FastAPI / Express routes and emits OpenAPI 3 spec plus markdown docs, using prompt-templated reflection.
 
 ## Features
@@ -14,6 +16,7 @@ Agent that parses FastAPI / Express routes and emits OpenAPI 3 spec plus markdow
 - Continuous documentation deployment via GitHub Pages
 - Generates API deprecation and migration guides
 - Customizable API title and version via CLI options
+- Plugin interface for additional frameworks
 
 ## Quick Start
 ```bash
@@ -31,10 +34,15 @@ openapi-doc-generator --version
 Documentation for the example app in `examples/app.py` is automatically built
 and published to GitHub Pages whenever changes are pushed to `main`.
 
+## Logging
+The CLI emits informational logs to stderr. Set the `LOG_LEVEL` environment
+variable to `DEBUG` for verbose output during troubleshooting.
+
 ## Testing
 Run the test suite with:
 ```bash
-pytest -q
+coverage run -m pytest -q
+coverage html  # view HTML report in htmlcov/index.html
 ```
 
 ## Usage
@@ -107,3 +115,9 @@ All roadmap items have been completed:
 
 ## License
 MIT
+
+## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and development guidelines.
+
+## Extending
+See [EXTENDING.md](EXTENDING.md) for writing custom discovery plugins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openapi_doc_generator"
-version = "0.0.17"
+version = "0.1.0"
 requires-python = ">=3.8"
 dependencies = [
     "jinja2>=3.1",
@@ -16,6 +16,8 @@ dev = [
     "pytest",
     "ruff",
     "bandit",
+    "coverage",
+    "radon",
 ]
 
 [tool.setuptools]
@@ -23,6 +25,7 @@ package-dir = {"" = "src"}
 packages = [
     "openapi_doc_generator",
     "openapi_doc_generator.templates",
+    "openapi_doc_generator.plugins",
 ]
 
 [project.scripts]

--- a/src/openapi_doc_generator/__init__.py
+++ b/src/openapi_doc_generator/__init__.py
@@ -21,6 +21,8 @@ except PackageNotFoundError:  # pragma: no cover - fallback for editable install
     __version__ = "0.0.0"
 
 from .cli import main as cli_main
+from .discovery import register_plugin, RoutePlugin
+from . import plugins  # noqa: F401 - register built-in plugins
 
 __all__ = [
     "echo",
@@ -39,6 +41,8 @@ __all__ = [
     "TestSuiteGenerator",
     "MigrationGuideGenerator",
     "SpecValidator",
+    "register_plugin",
+    "RoutePlugin",
     "cli_main",
     "__version__",
 ]

--- a/src/openapi_doc_generator/documentator.py
+++ b/src/openapi_doc_generator/documentator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import List
 
 from .discovery import RouteDiscoverer, RouteInfo
@@ -32,10 +33,15 @@ class DocumentationResult:
 class APIDocumentator:
     """Analyze an application to generate documentation artifacts."""
 
+    def __init__(self) -> None:
+        self._logger = logging.getLogger(self.__class__.__name__)
+
     def analyze_app(self, app_path: str) -> DocumentationResult:
+        self._logger.info("Discovering routes from %s", app_path)
         routes = RouteDiscoverer(app_path).discover()
         try:
             schemas = SchemaInferer(app_path).infer()
         except FileNotFoundError:
+            self._logger.info("No models found in %s", app_path)
             schemas = []
         return DocumentationResult(routes=routes, schemas=schemas)

--- a/src/openapi_doc_generator/markdown.py
+++ b/src/openapi_doc_generator/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List
 
 from jinja2 import Template
@@ -15,6 +16,9 @@ class MarkdownGenerator:
     """Convert OpenAPI specifications into markdown documentation."""
 
     template_name: str = "api.md.jinja"
+
+    def __post_init__(self) -> None:
+        self._logger = logging.getLogger(self.__class__.__name__)
 
     def generate(self, spec: Dict[str, Any] | None) -> str:
         """Return markdown for the provided OpenAPI specification."""
@@ -41,4 +45,5 @@ class MarkdownGenerator:
             "title": spec.get("info", {}).get("title", "API"),
             "routes": routes,
         }
+        self._logger.debug("Rendering markdown for %d routes", len(routes))
         return template.render(context)

--- a/src/openapi_doc_generator/plugins/__init__.py
+++ b/src/openapi_doc_generator/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in and third-party plugins for route discovery."""
+
+from .aiohttp import AioHTTPPlugin  # noqa: F401 - register plugin on import
+
+__all__ = ["AioHTTPPlugin"]

--- a/src/openapi_doc_generator/plugins/aiohttp.py
+++ b/src/openapi_doc_generator/plugins/aiohttp.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import List
+
+from ..discovery import RouteInfo, RoutePlugin, register_plugin
+
+
+class AioHTTPPlugin(RoutePlugin):
+    """Discover routes defined with aiohttp."""
+
+    def detect(self, source: str) -> bool:
+        return "aiohttp" in source.lower()
+
+    def discover(self, app_path: str) -> List[RouteInfo]:
+        text = Path(app_path).read_text()
+        pattern = re.compile(
+            r"app\.router\.add_(get|post|put|patch|delete)\(['\"]([^'\"]+)['\"]"
+        )
+        routes: List[RouteInfo] = []
+        for method, path in pattern.findall(text):
+            name = path.strip("/").replace("/", "_") or "root"
+            routes.append(RouteInfo(path=path, methods=[method.upper()], name=name))
+        return routes
+
+
+register_plugin(AioHTTPPlugin())

--- a/src/openapi_doc_generator/schema.py
+++ b/src/openapi_doc_generator/schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import ast
 from pathlib import Path
+import logging
 from typing import List
 
 
@@ -30,12 +31,14 @@ class SchemaInferer:
 
     def __init__(self, file_path: str) -> None:
         self.file_path = Path(file_path)
+        self._logger = logging.getLogger(self.__class__.__name__)
         if not self.file_path.exists():
             raise FileNotFoundError(file_path)
 
     # Public API
     def infer(self) -> List[SchemaInfo]:
         """Return all discovered models in the file."""
+        self._logger.debug("Inferring models from %s", self.file_path)
         tree = ast.parse(self.file_path.read_text(), filename=str(self.file_path))
         models: List[SchemaInfo] = []
         for node in tree.body:
@@ -45,17 +48,21 @@ class SchemaInferer:
 
     # Internal helpers -------------------------------------------------
     def _is_model(self, node: ast.ClassDef) -> bool:
-        for deco in node.decorator_list:
-            if isinstance(deco, ast.Name) and deco.id == "dataclass":
-                return True
-            if isinstance(deco, ast.Attribute) and deco.attr == "dataclass":
-                return True
-        for base in node.bases:
-            if isinstance(base, ast.Name) and base.id == "BaseModel":
-                return True
-            if isinstance(base, ast.Attribute) and base.attr == "BaseModel":
-                return True
-        return False
+        def has_dataclass_decorator() -> bool:
+            return any(
+                isinstance(d, (ast.Name, ast.Attribute))
+                and getattr(d, "id", getattr(d, "attr", None)) == "dataclass"
+                for d in node.decorator_list
+            )
+
+        def inherits_base_model() -> bool:
+            return any(
+                isinstance(b, (ast.Name, ast.Attribute))
+                and getattr(b, "id", getattr(b, "attr", None)) == "BaseModel"
+                for b in node.bases
+            )
+
+        return has_dataclass_decorator() or inherits_base_model()
 
     def _process_class(self, node: ast.ClassDef) -> SchemaInfo:
         fields: List[FieldInfo] = []

--- a/src/openapi_doc_generator/spec.py
+++ b/src/openapi_doc_generator/spec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Dict, List, Any
 
 from .discovery import RouteInfo
@@ -37,6 +38,8 @@ class OpenAPISpecGenerator:
     version: str = "1.0.0"
 
     def generate(self) -> Dict[str, Any]:
+        logger = logging.getLogger(self.__class__.__name__)
+        logger.debug("Generating OpenAPI spec")
         spec: Dict[str, Any] = {
             "openapi": "3.0.0",
             "info": {"title": self.title, "version": self.version},

--- a/tests/test_aiohttp_plugin.py
+++ b/tests/test_aiohttp_plugin.py
@@ -1,0 +1,15 @@
+from openapi_doc_generator.discovery import RouteDiscoverer
+
+
+def test_aiohttp_plugin(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        "from aiohttp import web\n"
+        "app = web.Application()\n"
+        "app.router.add_get('/hello', lambda r: r)\n"
+    )
+    routes = RouteDiscoverer(str(app)).discover()
+    assert len(routes) == 1
+    r = routes[0]
+    assert r.path == "/hello"
+    assert r.methods == ["GET"]

--- a/tests/test_cli_invalid_old_spec.py
+++ b/tests/test_cli_invalid_old_spec.py
@@ -1,0 +1,28 @@
+import logging
+import pytest
+from openapi_doc_generator.cli import main
+
+
+def test_cli_invalid_old_spec(tmp_path, caplog, capsys):
+    app = tmp_path / "app.py"
+    app.write_text(
+        "from fastapi import FastAPI\napp=FastAPI()\n@app.get('/')\ndef hi():\n    return 'hi'\n"
+    )
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad")
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    "--app",
+                    str(app),
+                    "--format",
+                    "guide",
+                    "--old-spec",
+                    str(bad),
+                ]
+            )
+    assert "invalid json" in caplog.text.lower()
+    err = capsys.readouterr().err.lower()
+    assert "--old-spec is not valid json" in err

--- a/tests/test_cli_migration_guide.py
+++ b/tests/test_cli_migration_guide.py
@@ -10,14 +10,16 @@ def test_cli_migration(tmp_path, capsys):
     old_spec = tmp_path / "old.json"
     old_spec.write_text(json.dumps({"paths": {"/old": {"get": {}}}}))
 
-    main([
-        "--app",
-        str(app),
-        "--format",
-        "guide",
-        "--old-spec",
-        str(old_spec),
-    ])
+    main(
+        [
+            "--app",
+            str(app),
+            "--format",
+            "guide",
+            "--old-spec",
+            str(old_spec),
+        ]
+    )
     out = capsys.readouterr().out
     assert "GET /old" in out
     assert "GET /new" in out

--- a/tests/test_cli_spec_info.py
+++ b/tests/test_cli_spec_info.py
@@ -7,16 +7,18 @@ def test_cli_custom_title_version(tmp_path, capsys):
     app.write_text(
         "from fastapi import FastAPI\napp = FastAPI()\n@app.get('/')\ndef root():\n    return 'hi'\n"
     )
-    main([
-        "--app",
-        str(app),
-        "--format",
-        "openapi",
-        "--title",
-        "My API",
-        "--api-version",
-        "2.0",
-    ])
+    main(
+        [
+            "--app",
+            str(app),
+            "--format",
+            "openapi",
+            "--title",
+            "My API",
+            "--api-version",
+            "2.0",
+        ]
+    )
     out = capsys.readouterr().out
     data = json.loads(out)
     assert data["info"]["title"] == "My API"

--- a/tests/test_migration_guide.py
+++ b/tests/test_migration_guide.py
@@ -8,6 +8,7 @@ def test_migration_guide():
     assert "POST /b" in guide
     assert "GET /c" in guide
 
+
 def test_migration_guide_no_changes():
     spec = {"paths": {"/a": {"get": {}}}}
     guide = MigrationGuideGenerator(spec, spec).generate_markdown()


### PR DESCRIPTION
## Summary
- add real repository path to CI badge
- revert stray radon threshold change
- auto-register built-in plugins via package import
- document plugin interface and contribution guide
- validate old spec JSON and add logging
- ensure formatting across source and tests

## Testing
- `ruff check .`
- `bandit -r src`
- `coverage run -m pytest -q`
- `coverage xml`
- `radon cc src -n C -s`


------
https://chatgpt.com/codex/tasks/task_e_68609d498b588329b8a4b373e2b3172b

## Summary by Sourcery

Enable extensible route discovery via a plugin interface with built-in aiohttp support and auto-registration; validate and log errors for old-spec JSON in the CLI; centralize CLI output generation; introduce structured logging; enhance CI with coverage and complexity checks; update documentation with contribution and extension guides; bump version to 0.1.0; enforce consistent formatting across the codebase.

New Features:
- Introduce plugin architecture for route discovery with built-in aiohttp support
- Auto-register plugins on package import to simplify framework extension
- Validate CLI `--old-spec` input as JSON and log errors on invalid input

Enhancements:
- Centralize CLI output generation via a new helper
- Add structured logging across modules with configurable log levels
- Refactor schema inference and migration guide logic for clarity

Build:
- Bump package version to 0.1.0 and add coverage and radon to project dependencies

CI:
- Expand CI to install coverage and radon, collect and upload coverage reports, and enforce cyclomatic complexity

Documentation:
- Add CONTRIBUTING and EXTENDING guides and update README with CI badge, plugin interface, and logging instructions

Tests:
- Add tests for aiohttp plugin discovery and invalid old-spec handling and standardize test formatting

Chores:
- Restore correct repository path in CI badge and apply code formatting consistency across source and tests