### PR TITLE
Add plugin cleanup fixtures and teardown for test isolation

### DIFF
--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -1,7 +1,16 @@
 import types
 from importlib import metadata
+import pytest
 
 from openapi_doc_generator.discovery import RoutePlugin, get_plugins, _PLUGINS
+
+
+@pytest.fixture(autouse=True)
+def clean_plugins():
+    """Ensure plugins are cleared before and after each test."""
+    _PLUGINS.clear()
+    yield
+    _PLUGINS.clear()
 
 
 class Dummy(RoutePlugin):
@@ -13,7 +22,6 @@ class Dummy(RoutePlugin):
 
 
 def test_entry_point_loading(monkeypatch):
-    _PLUGINS.clear()
 
     def fake_entry_points(*, group: str):
         assert group == "openapi_doc_generator.plugins"

--- a/tests/test_plugin_loading_refactoring.py
+++ b/tests/test_plugin_loading_refactoring.py
@@ -13,6 +13,10 @@ class TestPluginLoadingRefactoring:
         """Clear plugins before each test."""
         _PLUGINS.clear()
     
+    def teardown_method(self):
+        """Clear plugins after each test to ensure test isolation."""
+        _PLUGINS.clear()
+    
     def test_load_single_plugin_success(self):
         """Test successful plugin loading."""
         # Create a mock entry point and plugin class

--- a/tests/test_provide-cli-command-to-output-markdown-docs.py
+++ b/tests/test_provide-cli-command-to-output-markdown-docs.py
@@ -1,6 +1,15 @@
 import logging
 import pytest
 from openapi_doc_generator.cli import main
+from openapi_doc_generator.discovery import _PLUGINS
+
+
+@pytest.fixture(autouse=True)
+def clean_plugins():
+    """Ensure plugins are cleared before and after each test."""
+    _PLUGINS.clear()
+    yield
+    _PLUGINS.clear()
 
 
 def test_success(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Introduces fixtures and teardown methods to clear the global `_PLUGINS` registry before and after tests
- Ensures test isolation and prevents plugin state leakage across tests

## Changes

### Tests
- **test_plugin_entry_points.py**: Added a pytest fixture `clean_plugins` to clear `_PLUGINS` before and after each test
- **test_plugin_loading_refactoring.py**: Added `teardown_method` to clear `_PLUGINS` after each test, complementing existing setup
- **test_provide-cli-command-to-output-markdown-docs.py**: Added a pytest fixture `clean_plugins` to clear `_PLUGINS` before and after each test

## Test plan
- [x] Run all tests to verify no plugin state leaks between tests
- [x] Confirm tests pass consistently with the new cleanup logic
- [x] Validate that plugin loading and detection tests behave as expected with isolated plugin state

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1ea6e661-f08e-48fd-bb44-3eb20aafb2b8